### PR TITLE
Fixed invincibility flag.

### DIFF
--- a/src/Chalapa13/WorldGuard/EventListener.php
+++ b/src/Chalapa13/WorldGuard/EventListener.php
@@ -324,13 +324,14 @@ class EventListener implements Listener {
     }
     
     public function onHurt(EntityDamageEvent $event) {
-        $reg = $this->plugin->getRegionByPlayer($event->getEntity());
-        if ($reg->getFlag("invincible") === "true"){
-            $entity = $event->getEntity();
-            if($entity instanceof Player) {
-                $event->setCancelled();
+        if(($region = $this->plugin->getRegionFromPosition($event->getEntity()->getPosition())) !== ""){
+            if ($this->plugin->getRegionFromPosition($event->getEntity()->getPosition())->getFlag("invincible") === "true"){
+                if($event->getEntity() instanceof Player) {
+                    $event->setCancelled();
                 }
+            }
         }
+        return;
     }
 
     /**


### PR DESCRIPTION
Due to a mistake, the player was always assumed to be in a region and the server would crash when trying to get information from a null region.