### PR TITLE
Version 1.1.1.0

### DIFF
--- a/src/Chalapa13/WorldGuard/Region.php
+++ b/src/Chalapa13/WorldGuard/Region.php
@@ -105,6 +105,7 @@ class Region {
 
     public function getFlag(string $flag)
     {
+        //TODO: Move priority from returning the region name, to just returning the value of the flag on the highest priority region.
         return $this->flags[$flag];
     }
 
@@ -128,7 +129,7 @@ class Region {
             } else {
                 $this->flags["effects"][$value] = 0;
                 $this->effects[$value] = new EffectInstance(Effect::getEffect($value), 999999999, 0);
-                return TF::YELLOW.'Added "'.($this->effects[$value])->getName().' I" effect to "'.$this->name.'" region.';
+                return TF::YELLOW.'Added "'.($this->effects[$value])->getId().' I" effect to "'.$this->name.'" region.';
             }
             return;
         }


### PR DESCRIPTION
* Optimized code, removed unneeded comments, and make everything overall more efficient.
* Fixed messages causing an error.
* Fixed a bug where effects would crash the server when exiting a region.
* Fixed a bug where all effects would be removed upon leaving a region.
* Fixed color code symbol being corrupted and causing colors to (potentially) crash the server.
* Fixed eating could be bypassed, and made the flag more efficient.
+ Added worldguard.bypass.fly.<region> permission to disable regions controlling flight of server OPs