### PR TITLE
Version 1.1.6

### DIFF
--- a/src/Chalapa13/WorldGuard/Region.php
+++ b/src/Chalapa13/WorldGuard/Region.php
@@ -55,7 +55,7 @@ class Region {
         $this->flags = $flags;
 
         foreach ($this->flags["effects"] as $id => $amplifier) {
-            $this->effects[$id] = new EffectInstance(Effect::getEffect($id), 999999999, $amplifier);
+            $this->effects[$id] = new EffectInstance(Effect::getEffect($id), 999999999, $amplifier, false);
         }
 
         $this->vector1 = new Vector3(...$pos1);
@@ -121,7 +121,7 @@ class Region {
                 if (is_numeric($avalue[1])) {
                     $this->flags["effects"][$value] = $avalue[1];
                     $effectType = Effect::getEffect($value);
-                    $this->effects[$value] = new EffectInstance($effectType, 999999999, --$avalue[1]);
+                    $this->effects[$value] = new EffectInstance($effectType, 999999999, --$avalue[1], false);
                     return TF::YELLOW.'Added "'.($this->effects[$value])->getType()->getName().' '.Utils::getRomanNumber(++$avalue[1]).'" effect to "'.$this->name.'" region.';
                 } else {
                     return TF::RED."Amplifier must be numerical.\n".TF::GRAY.'Example: /region flags set '.$this->name.' '.$value.' 1';


### PR DESCRIPTION
+ Added hunger flag (Credit to @Suerion#1365)
+ Added adventure mode to GUI game-mode list. (Credit to @Suerion#1365)
* Fixed bypass permission for Game-Mode was missing a dot, it is now worldguard.bypass.gamemode.<regionname>
* Fixed bypass permission for Fly was missing a dot, it is now worldguard.bypass.fly.<regionname>
* Fixed a bug where entering and leaving a region with the console-cmd flag enabled would cause effects not be applied or removed.
* Fixed fly-mode affected people in Creative Mode.
* Fixed deny-msg flag did not work for the use flag.
* Fixed entities were parsed as Players and caused the server to crash.
* Fixed entities could not be damaged when the PvP flag was set to false.
* Fixed a bug where world names with spaces were not handled properly by the GUI.
- Removed Particles from region effects.