### PR TITLE
Version 1.1.6

### DIFF
--- a/src/Chalapa13/WorldGuard/EventListener.php
+++ b/src/Chalapa13/WorldGuard/EventListener.php
@@ -153,7 +153,9 @@ class EventListener implements Listener {
                     if($player->hasPermission("worldguard.usenoteblock." . $reg->getName()) && ($block === Block::BEACON ))
                         return;
                      if (in_array($block, self::USABLES)) {
-                        $player->sendMessage(TF::RED.'You cannot interact with '.$event->getBlock()->getName().'s.');
+                        if ($reg->getFlag("deny-msg") === "true") {
+                            $player->sendMessage(TF::RED.'You cannot interact with '.$event->getBlock()->getName().'s.');
+                        }
                         $event->setCancelled();
                         return;
                     }
@@ -283,7 +285,7 @@ class EventListener implements Listener {
         if (($victim) instanceof Player) {
             if (($reg = $this->plugin->getRegionByPlayer($victim)) !== "") {
                 if ($reg->getFlag("pvp") === "false"){
-         	    	if(($damager) instanceof Player) {
+         	    	if(($damager) instanceof Player && ($victim) instanceof Player) {
                         if ($reg->getFlag("deny-msg") === "true") {
                             $damager->sendMessage(TF::RED. $this->plugin->resourceManager->getMessages()["denied-pvp"]);
                         }
@@ -295,7 +297,7 @@ class EventListener implements Listener {
             if (($damager) instanceof Player) {
                 if (($reg = $this->plugin->getRegionByPlayer($damager)) !== "") {
                     if ($reg->getFlag("pvp") === "false"){
-                        if(($damager) instanceof Player) {
+                        if(($damager) instanceof Player && ($victim) instanceof Player) {
                             if ($reg->getFlag("deny-msg") === "true") {
                                 $damager->sendMessage(TF::RED. $this->plugin->resourceManager->getMessages()["denied-pvp"]);
                             }
@@ -506,7 +508,7 @@ class EventListener implements Listener {
     public function noHunger(PlayerExhaustEvent $exhaustEvent){
         $player = $exhaustEvent->getPlayer();
         if(($region = $this->plugin->getRegionByPlayer($exhaustEvent->getPlayer())) !== ""){
-            if($region->getFlag("nohunger") === "true") {
+            if($region->getFlag("hunger") === "false") {
                 $exhaustEvent->setCancelled(true);
             }
         }


### PR DESCRIPTION
+ Added hunger flag (Credit to @Suerion#1365)
+ Added adventure mode to GUI game-mode list. (Credit to @Suerion#1365)
* Fixed bypass permission for Game-Mode was missing a dot, it is now worldguard.bypass.gamemode.<regionname>
* Fixed bypass permission for Fly was missing a dot, it is now worldguard.bypass.fly.<regionname>
* Fixed a bug where entering and leaving a region with the console-cmd flag enabled would cause effects not be applied or removed.
* Fixed fly-mode affected people in Creative Mode.
* Fixed deny-msg flag did not work for the use flag.
* Fixed entities were parsed as Players and caused the server to crash.
* Fixed entities could not be damaged when the PvP flag was set to false.
* Fixed a bug where world names with spaces were not handled properly by the GUI.
- Removed Particles from region effects.