### PR TITLE
Version 1.1.6

### DIFF
--- a/src/Chalapa13/WorldGuard/GUI.php
+++ b/src/Chalapa13/WorldGuard/GUI.php
@@ -175,7 +175,7 @@ class GUI
                 new Toggle($lang["gui_flag_enderpearl"], filter_var($rg->getFlag("enderpearl"), FILTER_VALIDATE_BOOLEAN)),
                 new Dropdown($lang["gui_flag_fly_mode"], ["Vanilla", $lang["gui_enabled"], $lang["gui_disabled"], "Supervised"]),
                 new Toggle($lang["gui_flag_eat"], filter_var($rg->getFlag("eat"), FILTER_VALIDATE_BOOLEAN)),
-                new Toggle($lang["gui_flag_nohunger"], filter_var($rg->getFlag("nohunger"), FILTER_VALIDATE_BOOLEAN)),
+                new Toggle($lang["gui_flag_hunger"], filter_var($rg->getFlag("hunger"), FILTER_VALIDATE_BOOLEAN)),
                 new Toggle($lang["gui_flag_dmg_animals"], filter_var($rg->getFlag("allow-damage-animals"), FILTER_VALIDATE_BOOLEAN)),
                 new Toggle($lang["gui_flag_dmg_monsters"], filter_var($rg->getFlag("allow-damage-monsters"), FILTER_VALIDATE_BOOLEAN)),
                 new Toggle($lang["gui_flag_leaf_decay"], filter_var($rg->getFlag("allow-leaves-decay"), FILTER_VALIDATE_BOOLEAN)),
@@ -187,41 +187,41 @@ class GUI
             function(Player $player, CustomFormResponse $response) : void{
                 list($pvpFlag, $xpFlag, $invincibleFlag, $fallDmgFlag, $useFlag, $itemDropFlag, $explosionsFlag,
                     $notifyEnterFlag, $notifyLeaveFlag, $potionsFlag, $allowEnterFlag, $allowLeaveFlag,
-                    $gamemodeFlag, $sleepFlag, $sendChatFlag, $receiveChatFlag, $enderPearlFlag, $flyModeFlag, $eatingFlag, $noHungerFlag,
+                    $gamemodeFlag, $sleepFlag, $sendChatFlag, $receiveChatFlag, $enderPearlFlag, $flyModeFlag, $eatingFlag, $HungerFlag,
                     $damageAnimalsFlag, $damageMonstersFlag, $leafDecayFlag, $plantGrowthFlag, $spreadingFlag, $blockBurnFlag,
                     $priorityFlag) = $response->getValues();
 
                 $lang = Utils::getPluginFromIssuer($player)->resourceManager->getLanguagePack();
                    
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " pvp " . var_export($pvpFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " exp-drops " . var_export($xpFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " invincible " . var_export($invincibleFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " fall-dmg " . var_export($fallDmgFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " use " . var_export($useFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " item-drop " . var_export($itemDropFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " explosion " . var_export($explosionsFlag, true));
-                if($notifyEnterFlag != '' || $notifyEnterFlag != ' '){$player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " notify-enter " . $notifyEnterFlag);}
-                if($notifyLeaveFlag != '' || $notifyLeaveFlag != ' '){$player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " notify-leave " . $notifyLeaveFlag);}
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " potions " . var_export($potionsFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " allowed-enter " . var_export($allowEnterFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " allowed-leave " . var_export($allowLeaveFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " sleep " . var_export($sleepFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " send-chat " . var_export($sendChatFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " receive-chat " . var_export($receiveChatFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " enderpearl " . var_export($enderPearlFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" pvp " . var_export($pvpFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" exp-drops " . var_export($xpFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" invincible " . var_export($invincibleFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" fall-dmg " . var_export($fallDmgFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" use " . var_export($useFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" item-drop " . var_export($itemDropFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" explosion " . var_export($explosionsFlag, true));
+                if($notifyEnterFlag != '' || $notifyEnterFlag != ' '){$player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" notify-enter " . $notifyEnterFlag);}
+                if($notifyLeaveFlag != '' || $notifyLeaveFlag != ' '){$player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" notify-leave " . $notifyLeaveFlag);}
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" potions " . var_export($potionsFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" allowed-enter " . var_export($allowEnterFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" allowed-leave " . var_export($allowLeaveFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" sleep " . var_export($sleepFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" send-chat " . var_export($sendChatFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" receive-chat " . var_export($receiveChatFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" enderpearl " . var_export($enderPearlFlag, true));
 
                 switch ($gamemodeFlag)
                 {
                     case $lang["gui_gm_survival"]:
-                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " game-mode survival");
+                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" game-mode survival");
                         break;
 
                     case $lang["gui_gm_creative"]:
-                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " game-mode creative");
+                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" game-mode creative");
                         break;
                         
                      case $lang["gui_gm_adventure"]:
-                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " game-mode adventure");
+                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" game-mode adventure");
                         break;
                 }
 
@@ -229,31 +229,31 @@ class GUI
                 switch ($flyModeFlag)
                 {
                     case "Vanilla":
-                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " fly-mode 0");
+                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" fly-mode 0");
                         break;
 
                     case $lang["gui_enabled"]:
-                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " fly-mode 1");
+                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" fly-mode 1");
                         break;
 
                     case $lang["gui_disabled"]:
-                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " fly-mode 2");
+                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" fly-mode 2");
                         break;
 
                     case "Supervised":
-                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " fly-mode 3");
+                        $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" fly-mode 3");
                         break;
                 }
 
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " eat " . var_export($eatingFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " nohunger " . var_export($noHungerFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " allow-damage-animals " . var_export($damageAnimalsFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " allow-damage-monsters " . var_export($damageMonstersFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " allow-leaves-decay " . var_export($leafDecayFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " allow-plant-growth " . var_export($plantGrowthFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " allow-spreading " . var_export($spreadingFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " allow-block-burn " . var_export($blockBurnFlag, true));
-                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set " . self::$currentlyEditedRg . " priority " . intval($priorityFlag));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" eat " . var_export($eatingFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" hunger " . var_export($HungerFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" allow-damage-animals " . var_export($damageAnimalsFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" allow-damage-monsters " . var_export($damageMonstersFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" allow-leaves-decay " . var_export($leafDecayFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" allow-plant-growth " . var_export($plantGrowthFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" allow-spreading " . var_export($spreadingFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" allow-block-burn " . var_export($blockBurnFlag, true));
+                $player->getServer()->dispatchCommand(new ConsoleCommandSender(), "rg flags set \"" . self::$currentlyEditedRg . "\" priority " . intval($priorityFlag));
                 $player->sendMessage(TF::GREEN."Region ".self::$currentlyEditedRg." updated successfully!");
 
                 self::$currentlyEditedRg = "";


### PR DESCRIPTION
+ Added hunger flag (Credit to @Suerion#1365)
+ Added adventure mode to GUI game-mode list. (Credit to @Suerion#1365)
* Fixed bypass permission for Game-Mode was missing a dot, it is now worldguard.bypass.gamemode.<regionname>
* Fixed bypass permission for Fly was missing a dot, it is now worldguard.bypass.fly.<regionname>
* Fixed a bug where entering and leaving a region with the console-cmd flag enabled would cause effects not be applied or removed.
* Fixed fly-mode affected people in Creative Mode.
* Fixed deny-msg flag did not work for the use flag.
* Fixed entities were parsed as Players and caused the server to crash.
* Fixed entities could not be damaged when the PvP flag was set to false.
* Fixed a bug where world names with spaces were not handled properly by the GUI.
- Removed Particles from region effects.