### PR TITLE
Version 1.1.6

### DIFF
--- a/src/Chalapa13/WorldGuard/ResourceUtils/ResourceUpdater.php
+++ b/src/Chalapa13/WorldGuard/ResourceUtils/ResourceUpdater.php
@@ -87,7 +87,7 @@ class ResourceUpdater
             "gui_enabled" => "Enabled",
             "gui_disabled" => "Disabled",
             "gui_flag_eat" => "Allow eating",
-            "gui_flag_nohunger" => "Enable NoHunger",
+            "gui_flag_hunger" => "Disable Hunger",
             "gui_flag_dmg_animals" => "Allow damaging of animals",
             "gui_flag_dmg_monsters" => "Allow damaging of monsters",
             "gui_flag_leaf_decay" => "Allow leaf decay",


### PR DESCRIPTION
+ Added hunger flag (Credit to @Suerion#1365)
+ Added adventure mode to GUI game-mode list. (Credit to @Suerion#1365)
* Fixed bypass permission for Game-Mode was missing a dot, it is now worldguard.bypass.gamemode.<regionname>
* Fixed bypass permission for Fly was missing a dot, it is now worldguard.bypass.fly.<regionname>
* Fixed a bug where entering and leaving a region with the console-cmd flag enabled would cause effects not be applied or removed.
* Fixed fly-mode affected people in Creative Mode.
* Fixed deny-msg flag did not work for the use flag.
* Fixed entities were parsed as Players and caused the server to crash.
* Fixed entities could not be damaged when the PvP flag was set to false.
* Fixed a bug where world names with spaces were not handled properly by the GUI.
- Removed Particles from region effects.